### PR TITLE
Add shebang

### DIFF
--- a/filemaid.py
+++ b/filemaid.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import abc
 import argparse
 import functools


### PR DESCRIPTION
This makes Unix-like systems treat the script as executable and will automatically launch the Python interpreter.